### PR TITLE
Global t Function Type

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,25 +1,9 @@
+import { t as translate } from '../helpers/translate';
+
 declare global {
   export type ObjectOf<T> = { [key: string]: T };
 
-  // TODO: We should be able to infer this type by importing the
-  // real implementation, but I can't get that to work.
-  export type TranslatorFunction = {
-    (input: string, params?: { [key: string]: unknown }): string;
-    frag: (
-      input: string,
-      params: {
-        [key: string]:
-          | null
-          | undefined
-          | number
-          | string
-          | boolean
-          | ((s: string) => unknown);
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ) => any;
-  };
-  export const t: TranslatorFunction;
+  export const t: typeof translate;
 
   export const global: typeof globalThis;
 }


### PR DESCRIPTION
It seems that exporting/importing directly inside the `declare global` scope doesn't work as we expect it to.

![image](https://user-images.githubusercontent.com/16997526/77397800-dad55900-6dd8-11ea-84ce-968286772a21.png)

Instead, I import the function outside of the `declare` scope and use `typeof` to get the type we need.