### PR TITLE
fix: fix multiple missing key warnings

### DIFF
--- a/src/components/FlowCarousel.tsx
+++ b/src/components/FlowCarousel.tsx
@@ -44,13 +44,13 @@ function FlowCarousel(props: Props) {
 
   return (
     <Carousel currentIndex={currentIndex} onIndexChanged={setCurrentIndex}>
-      {content.screens?.map((s) => {
+      {content.screens?.map((s, i) => {
         let Screen = Screens[s.type];
         if (!Screen) {
           // Specified screen type not found.
           return null;
         }
-        return <Screen flow={flow} screen={s} />;
+        return <Screen key={i} flow={flow} screen={s} />;
       })}
     </Carousel>
   );

--- a/src/components/FlowCarousel.tsx
+++ b/src/components/FlowCarousel.tsx
@@ -83,9 +83,11 @@ let Screens: Record<ScreenType, ComponentType<any> | null> = {
         {screen.bodyTexts?.map((text) => (
           <BodyText key={text}>
             {/* TODO: Should not use non-literal string with translate function */}
-            {t.frag(text, {
-              em: (text) => <EmText>{text}</EmText>,
-            })}
+            {t
+              .frag(text, {
+                em: (text) => <EmText>{text}</EmText>,
+              })
+              .toElements()}
           </BodyText>
         ))}
         {imageUri && <Image source={{ uri: imageUri }} />}

--- a/src/components/FlowCarousel.tsx
+++ b/src/components/FlowCarousel.tsx
@@ -87,7 +87,7 @@ let Screens: Record<ScreenType, ComponentType<any> | null> = {
               .frag(text, {
                 em: (text) => <EmText>{text}</EmText>,
               })
-              .toElements()}
+              .toElement()}
           </BodyText>
         ))}
         {imageUri && <Image source={{ uri: imageUri }} />}

--- a/src/helpers/translate.ts
+++ b/src/helpers/translate.ts
@@ -1,3 +1,5 @@
+import { createElement, Fragment, ReactNode } from 'react';
+
 type ParamsObject = {
   [key: string]: unknown;
 };
@@ -28,11 +30,24 @@ export function t(input: string, params?: ParamsObject): string {
   }
 }
 
+interface ResultsArray<T = unknown> extends Array<T> {
+  toElements(): ReactNode;
+}
+
+let toElements = (frags: Array<ReactNode>) =>
+  frags.map((s, i) => createElement(Fragment, { key: i }, s));
+
+let createResultsArray = (): ResultsArray => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let results: any = [];
+  results.toElements = () => toElements(results);
+  return results;
+};
+
 // Process a string with fragments inside.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-t.frag = (input: string, params: ParamsWithResolver): any => {
+t.frag = (input: string, params: ParamsWithResolver): ResultsArray => {
   let string = t(input, params);
-  let results: Array<unknown> = [];
+  let results = createResultsArray();
   let lastIndex = 0;
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore

--- a/src/helpers/translate.ts
+++ b/src/helpers/translate.ts
@@ -31,16 +31,16 @@ export function t(input: string, params?: ParamsObject): string {
 }
 
 interface ResultsArray<T = unknown> extends Array<T> {
-  toElements(): ReactNode;
+  toElement(): ReactNode;
 }
 
-let toElements = (frags: Array<ReactNode>) =>
-  frags.map((s, i) => createElement(Fragment, { key: i }, s));
+let toElement = (elements: Array<ReactNode>) =>
+  createElement(Fragment, null, ...elements);
 
 let createResultsArray = (): ResultsArray => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let results: any = [];
-  results.toElements = () => toElements(results);
+  results.toElement = () => toElement(results);
   return results;
 };
 


### PR DESCRIPTION
The ResultsArray interface is kinda hacky, but it reminds me of ReasonML where you just do `somelist |> Array.of_list |> ReasonReact.array`, 😆 

Feel free to land or modify this PR.