### PR TITLE
Update web version preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/WorldHealthOrganization/app/issues/193
 
 ## Web Version
 
-1. Point your mobile browser at: https://kodefox.github.io/who-app/
+1. Point your mobile browser at: https://kodefox.github.io/who-app-rn/
 
 ## Screenshots
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "node_modules/expo/AppEntry.js",
-  "homepage": "https://kodefox.github.io/who-app",
+  "homepage": "https://kodefox.github.io/who-app-rn",
   "scripts": {
     "start": "expo start",
     "android": "yarn start --android",


### PR DESCRIPTION
The `homepage` in `package.json` needs to be manually updated after renaming the repo.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/19742419/77472345-55888d80-6e46-11ea-9fde-993cf6b8d77b.png">
